### PR TITLE
Fix typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,9 @@ key.
 Is it a URL or a search term?
 ------------------
 
+Parse URL...
+------------
+
 Check HSTS list...
 ------------------
 
@@ -82,7 +85,7 @@ Convert UTF-8 characters in hostname...
 * The browser checks the hostname for characters that are not in ``a-z``,
   ``A-Z``, ``0-9``, ``-``, or ``.``.
 * Since the hostname is ``google.com`` there won't be any, but if there were the
-  browser would apply `Punycode`_ decoding to the hostname portion of the URL.
+  browser would apply `Punycode`_ encoding to the hostname portion of the URL.
 
 DNS lookup...
 -------------


### PR DESCRIPTION
If the hostname contains non-ASCII characters, it gets Punycode-encoded, not decoded.