### PR TITLE
started filling the TLS part

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,11 +185,55 @@ This send and receive happens multiple times following the TCP connection flow:
 UDP packets
 ~~~~~~~~~~~
 
-TLS handshake...
-----------------
+
 
 TCP packets
 ~~~~~~~~~~~
+
+
+
+Security: Encryption/Authentication
+-------------------------------------
+
+If the URL is displaying `https` instead of `http`, this means that in the TCP packets, 
+the **TCP payloads** are **encrypted**.
+This means that if someone could "listen" to the traffic and see the packets in transit, 
+he wouldn't be able to tell what is being requested to the server and what is being sent to the client.
+
+To **encrypt** packets we need a key. And for the Client (the one initiating the connection) and the Server 
+(the one who received the first request) to share a secret key, we first need to do a key exchange.
+This is also called a **handshake**.
+
+First what you need to know is that **TLS** (previously called **SSL**) is a set of rules and guides that both
+the Client and the Server use to take care of this handshake thing and to encrypt/decrypt the TCP packets 
+and to **authenticate** the server (or sometimes both parties).
+This TLS thing is often done by using an opensource software called **OpenSSL**, browser often uses that so 
+the encryption and authentication process is done at the Application level of the OSI model.
+
+The **Authentication** part works thanks Public Key Infrastructure (PKI), and this allows the Client to make sure
+that he's really talking to Google and not someone else.
+
+### Encryption
+
+* ciphers
+
+### Authentication
+
+* Asymetric Encryption
+* CA
+* root certificates in browser
+
+### TLS
+
+In reality it's more complext han that. The Client sends a ClientHello, the Server sends a ServerHello.
+They then agree on a set of protocols. The Server sends his Certificate (the Client can also do this) and 
+the Client verifies the Server's Certificate (this is called Authentication). Then a couple of messages are 
+sent encrypted to see if the encryption process works. There are also other things like session resumption, 
+triple handshakes, perfect forward secrecy...
+
+more info about TLS from Thomas Pornin:  
+* http://security.stackexchange.com/questions/20803/how-does-ssl-tls-work/20847#20847
+* http://security.blogoverflow.com/2012/10/qotw-37-how-does-ssl-work/
 
 HTTP protocol...
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -213,11 +213,24 @@ the encryption and authentication process is done at the Application level of th
 TLS also not only encrypts the packets but **authenticate** the server as well. This allows the Client to make sure
 that he's really talking to Google (for example) and not someone else. It works thanks to a Public Key Infrastructure (PKI).
 
+
+###Authentication
+
+* The cryptography used to authenticate the server (and sometimes the Client as well) comes from **asymmetric encryption**.
+* CA
+* root certificates in browser
+
 ###Handshake
 
 The encryption is done thanks to **symmetric encryption**. Because it is faster than **asymmetric encryption**. 
 It's problematic because symmetric encryption works with only one key (the same key allows encryption _and_ decryption).
 This is why we do a Handshake.
+
+To do a Handshake 2 big protocols can be used (depending on what the Client and the Server previously agreed):
+* Diffie-Hellman
+* RSA
+
+We'll just explain RSA because it is often used instead of Diffie-Hellman since it provides **authentication**.
 
 ###Encryption
 
@@ -226,12 +239,6 @@ For example AES can only encrypt a block of 128 bits, that's why we need a mode 
 that are longer. With that we can encrypt messages of length exactly a multiple of 128bits. That's why a 
 padding method must be used as well (for example, adding 0s until the length of the message is reaching a multiple of
 128 bits).
-
-###Authentication
-
-* The cryptography used to authenticate the server (and sometimes the Client as well) comes from **asymmetric encryption**.
-* CA
-* root certificates in browser
 
 ### TLS protocol
 

--- a/README.rst
+++ b/README.rst
@@ -210,20 +210,30 @@ and to **authenticate** the server (or sometimes both parties).
 This TLS thing is often done by using an opensource software called **OpenSSL**, browser often uses that so 
 the encryption and authentication process is done at the Application level of the OSI model.
 
-The **Authentication** part works thanks Public Key Infrastructure (PKI), and this allows the Client to make sure
-that he's really talking to Google and not someone else.
+TLS also not only encrypts the packets but **authenticate** the server as well. This allows the Client to make sure
+that he's really talking to Google (for example) and not someone else. It works thanks to a Public Key Infrastructure (PKI).
 
-### Encryption
+###Handshake
 
-* ciphers
+The encryption is done thanks to **symmetric encryption**. Because it is faster than **asymmetric encryption**. 
+It's problematic because symmetric encryption works with only one key (the same key allows encryption _and_ decryption).
+This is why we do a Handshake.
 
-### Authentication
+###Encryption
 
-* Asymetric Encryption
+We use block ciphers like AES, with a mode of operation that allows the block cipher to encrypt several blocks 
+For example AES can only encrypt a block of 128 bits, that's why we need a mode of operation to encrypt messages
+that are longer. With that we can encrypt messages of length exactly a multiple of 128bits. That's why a 
+padding method must be used as well (for example, adding 0s until the length of the message is reaching a multiple of
+128 bits).
+
+###Authentication
+
+* The cryptography used to authenticate the server (and sometimes the Client as well) comes from **asymmetric encryption**.
 * CA
 * root certificates in browser
 
-### TLS
+### TLS protocol
 
 In reality it's more complext han that. The Client sends a ClientHello, the Server sends a ServerHello.
 They then agree on a set of protocols. The Server sends his Certificate (the Client can also do this) and 


### PR DESCRIPTION
I added an intro for the encryption/authentication part (previously called TLS)

I added 5 new titles:
- Encryption/Authentication (the intro)
- Authentication (prerequisite to handshake)
- Handshake (prerequisite to last section)
- Encryption (prerequisite to last section)
- TLS protocol (how it works)

Maybe we could do without the prerequisite and explain only the protocol...
