### PR TITLE
Make gender neutral.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ connection, but historically has been over PS/2 or ADB connections.
 
 *In the case of Virtual Keyboard (as in touch screen devices):*
 
-- In modern capacitive touch screens when the user puts his finger on the
+- In modern capacitive touch screens when the user puts their finger on the
   screen a tiny amount of current from the electrostatic field of the
   conductive layer gets transferred to the finger completing the circuit
   and creating a voltage dropping at that point on the screen so that the


### PR DESCRIPTION
Use *their* instead of *he or she* as individuals may define their gender in a diverse variety of ways.