### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,12 +198,12 @@ DNS lookup...
 -------------
 
 * Browser checks if the domain is in its cache.
-* If not found, calls ``gethostbyname`` library function (varies by OS) to do
+* If not found, calls ``getaddrinfo`` library function (or the legacy function ``gethostbyname``, varies by OS/browser) to do
   the lookup.
-* ``gethostbyname`` checks if the hostname can be resolved by reference in the
+* This checks if the hostname can be resolved by reference in the
   local ``hosts`` file (whose location `varies by OS`_) before trying to
   resolve the hostname through DNS.
-* If ``gethostbyname`` does not have it cached nor in the ``hosts`` file then a
+* If does not have it cached nor in the ``hosts`` file then a
   request is made to the known DNS server that was given to the network stack.
   This is typically the local router or the ISP's caching DNS server.
 


### PR DESCRIPTION
I guess all modern browsers use getaddrinfo instead of gethostbyname.
References:
http://beej.us/guide/bgnet/output/html/singlepage/bgnet.html#ip4to6
https://books.google.de/books?id=7Nf8xxgsM50C&pg=PA57&dq=socket.getaddrinfo&hl=de&sa=X&ei=S8rKVN37EsHYywPP6oLYBQ&ved=0CDQQ6AEwAg#v=onepage&q=socket.getaddrinfo&f=false
http://webmasters.stackexchange.com/questions/10927/using-multiple-a-records-for-my-domain-do-web-browsers-ever-try-more-than-one