### PR TITLE
Fix typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -564,7 +564,7 @@ an almost one-to-one relation to the markup.
 
 **The parsing algorithm**
 
-HTML cannot be parsed using the regular top down or bottom up parsers.
+HTML cannot be parsed using the regular top-down or bottom-up parsers.
 
 The reasons are:
 * The forgiving nature of the language.


### PR DESCRIPTION
Corrected use of "top down" and "bottom up" with accurate hyphenated versions "top-down" and "bottom-up".

![image](https://cloud.githubusercontent.com/assets/3825178/6131810/81c53778-b103-11e4-8932-675aea28d265.png)

