### PR TITLE
Remove sentence about Rockmelt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,7 @@ event and the entire auto-complete machinery kicks into high gear.
 Depending on your browser's algorithm and if you are in
 private/incognito mode or not various suggestions will be presented
 to you in the dropbox below the URL bar. Most of these algorithms
-prioritize results based on search history and bookmarks. Some
-browsers like Rockmelt even suggested your Facebook friends. You are
+prioritize results based on search history and bookmarks. You are
 going to type "google.com" so none of it matters, but a lot of code
 will run before you get there and the suggestions will be refined
 with each key press. It may even suggest "google.com" before you type it.


### PR DESCRIPTION
This browser was discontinued in 2013 (https://en.wikipedia.org/wiki/Rockmelt).
And this sentence had a typo in it.