### PR TITLE
Fixed UDP connection when making DNS request.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -289,8 +289,9 @@ Switch:
 Now that the network library has the IP address of either our DNS server or
 the default gateway it can resume its DNS process:
 
-* Port 53 is opened to send a UDP request to DNS server (if the response size
-  is too large, TCP will be used instead).
+* A UDP port is opened in client mode and make a request to DNS server which
+  listens UDP port 53 (if the response size is too large, TCP will be used 
+  instead).
 * If the local/ISP DNS server does not have it, then a recursive search is
   requested and that flows up the list of DNS servers until the SOA is reached,
   and if found an answer is returned.

--- a/README.rst
+++ b/README.rst
@@ -290,8 +290,9 @@ Now that the network library has the IP address of either our DNS server or
 the default gateway it can resume its DNS process:
 
 * A UDP port is opened in client mode and make a request to DNS server which
-  listens UDP port 53 (if the response size is too large, TCP will be used 
+  listens UDP port 53 (if the response size is too large, TCP will be used
   instead).
+
 * If the local/ISP DNS server does not have it, then a recursive search is
   requested and that flows up the list of DNS servers until the SOA is reached,
   and if found an answer is returned.


### PR DESCRIPTION
It was unclear that the port is opened for being a server or client. In many systems, client port is selected randomly from free ports by kernel. So it does not have to be 53 unless explicitly specified in client program and there is no process already listening that port. What is constant here is the listening port of the server.