### PR TITLE
Add PATCH HTTP Request method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -470,9 +470,9 @@ and IIS for Windows.
 
 * The HTTPD (HTTP Daemon) receives the request.
 * The server breaks down the request to the following parameters:
-   * HTTP Request Method (either ``GET``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``,
-     ``DELETE``, ``CONNECT``, ``OPTIONS``, or ``TRACE``). In the case of a URL
-     entered directly into the address bar, this will be ``GET``.
+   * HTTP Request Method (either ``GET``, ``HEAD``, ``POST``, ``PUT``,
+     ``PATCH``, ``DELETE``, ``CONNECT``, ``OPTIONS``, or ``TRACE``). In the 
+     case of a URL entered directly into the address bar, this will be ``GET``.
    * Domain, in this case - google.com.
    * Requested path/page, in this case - / (as no specific path/page was
      requested, / is the default path).

--- a/README.rst
+++ b/README.rst
@@ -471,7 +471,7 @@ and IIS for Windows.
 * The HTTPD (HTTP Daemon) receives the request.
 * The server breaks down the request to the following parameters:
    * HTTP Request Method (either ``GET``, ``HEAD``, ``POST``, ``PUT``,
-     ``PATCH``, ``DELETE``, ``CONNECT``, ``OPTIONS``, or ``TRACE``). In the 
+     ``PATCH``, ``DELETE``, ``CONNECT``, ``OPTIONS``, or ``TRACE``). In the
      case of a URL entered directly into the address bar, this will be ``GET``.
    * Domain, in this case - google.com.
    * Requested path/page, in this case - / (as no specific path/page was

--- a/README.rst
+++ b/README.rst
@@ -470,7 +470,7 @@ and IIS for Windows.
 
 * The HTTPD (HTTP Daemon) receives the request.
 * The server breaks down the request to the following parameters:
-   * HTTP Request Method (either ``GET``, ``HEAD``, ``POST``, ``PUT``,
+   * HTTP Request Method (either ``GET``, ``HEAD``, ``POST``, ``PUT``, ``PATCH``,
      ``DELETE``, ``CONNECT``, ``OPTIONS``, or ``TRACE``). In the case of a URL
      entered directly into the address bar, this will be ``GET``.
    * Domain, in this case - google.com.


### PR DESCRIPTION
PATCH was omitted from the list of HTTP Request methods
References:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods