### PR TITLE
Fixing terminology, since the DNS client does not "open" port 53

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -290,7 +290,7 @@ Switch:
 Now that the network library has the IP address of either our DNS server or
 the default gateway it can resume its DNS process:
 
-* The DNS client establishes a socket to UDP port 53 on the DNS server, 
+* The DNS client establishes a socket to UDP port 53 on the DNS server,
   using a source port above 1023.
 * If the response size is too large, TCP will be used instead.
 * If the local/ISP DNS server does not have it, then a recursive search is

--- a/README.rst
+++ b/README.rst
@@ -290,7 +290,8 @@ Switch:
 Now that the network library has the IP address of either our DNS server or
 the default gateway it can resume its DNS process:
 
-* The DNS client establishes a socket to UDP port 53 on the DNS server, using a source port above 1023.
+* The DNS client establishes a socket to UDP port 53 on the DNS server, 
+  using a source port above 1023.
 * If the response size is too large, TCP will be used instead.
 * If the local/ISP DNS server does not have it, then a recursive search is
   requested and that flows up the list of DNS servers until the SOA is reached,

--- a/README.rst
+++ b/README.rst
@@ -290,8 +290,8 @@ Switch:
 Now that the network library has the IP address of either our DNS server or
 the default gateway it can resume its DNS process:
 
-* Port 53 is opened to send a UDP request to DNS server (if the response size
-  is too large, TCP will be used instead).
+* The DNS client establishes a socket to UDP port 53 on the DNS server, using a source port above 1023.
+* If the response size is too large, TCP will be used instead.
 * If the local/ISP DNS server does not have it, then a recursive search is
   requested and that flows up the list of DNS servers until the SOA is reached,
   and if found an answer is returned.


### PR DESCRIPTION
The DNS client does not really "open" port 53, it connects to it. Also adding info on source ports.

Source:
http://web.deu.edu.tr/doc/oreily/networking/firewall/ch08_10.htm