### PR TITLE
ARP resolves an IP address to a MAC address

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -287,7 +287,7 @@ Switch:
     Target MAC: interface:mac:address:here
     Target IP: interface.ip.goes.here
 
-Now that the network library has the IP address of either our DNS server or
+Now that the network library has the MAC address of either our DNS server or
 the default gateway it can resume its DNS process:
 
 * The DNS client establishes a socket to UDP port 53 on the DNS server,


### PR DESCRIPTION
not the other way around. (one word changed)

The IP addresses of default gateway and DNS sever are already known before the "ARP process", because they were configured manually or via DHCP or in case of IPv6 for example via router advertisement.