### PR TITLE
Remove SPDY

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -417,11 +417,7 @@ control`_. This varies depending on the sender; the most common algorithms are
 HTTP protocol
 -------------
 
-If the web browser used was written by Google, instead of sending an HTTP
-request to retrieve the page, it will send a request to try and negotiate with
-the server an "upgrade" from HTTP to the SPDY protocol.
-
-If the client is using the HTTP protocol and does not support SPDY, it sends a
+If the client is using the HTTP protocol, it sends a
 request to the server of the form::
 
     GET / HTTP/1.1


### PR DESCRIPTION
Please read: https://blog.chromium.org/2016/02/transitioning-from-spdy-to-http2.html

Google Chrome deprecated SPDY in 2016 in favor of HTTP/2. I see several issues have been filed for this but the misleading information has not been removed.