### PR TITLE
Update the DNS lookup to move from Internet Service Provider(ISP) to …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,6 +219,8 @@ DNS lookup
 * If ``gethostbyname`` does not have it cached nor can find it in the ``hosts``
   file then it makes a request to the DNS server configured in the network
   stack. This is typically the local router or the ISP's caching DNS server.
+* The ISP (Internet Service Provider) here locate the Top Level Domain (e.g .com).
+  The TLD know the location of the authoritative name server(DNS server).
 * If the DNS server is on the same subnet the network library follows the
   ``ARP process`` below for the DNS server.
 * If the DNS server is on a different subnet, the network library follows


### PR DESCRIPTION
## DNS LOOKUP

update the DNS Lookup to point from Internet Service Provide(ISP) to locate the Top Level domain(TLD) which in turn lead to Authoritative name server.