### PR TITLE
[Chore]: DNS cache in Firefox

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,7 +210,7 @@ DNS lookup
 ----------
 
 * Browser checks if the domain is in its cache. (to see the DNS Cache in
-  Chrome, go to `chrome://net-internals/#dns <chrome://net-internals/#dns>`_).
+  Chrome, go to `chrome://net-internals/#dns <chrome://net-internals/#dns>`_, in Firefox go to `about:networking#dns`).
 * If not found, the browser calls ``gethostbyname`` library function (varies by
   OS) to do the lookup.
 * ``gethostbyname`` checks if the hostname can be resolved by reference in the


### PR DESCRIPTION
This PR adds the resource of where to find cached DNS records in _Firefox_ browser