### PR TITLE
commit on css rendering and parse css codes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -623,7 +623,10 @@ CSS interpretation
 ------------------
 
 * Parse CSS files, ``<style>`` tag contents, and ``style`` attribute
-  values using `"CSS lexical and syntax grammar"`_
+  values using `"CSS lexical and syntax grammar"`_ This process involes
+  tokenizing the CSS code into a series of tokens(keywords,selectors,properties, and values), building a parse tree from those tokens and generating a set of
+  rules from the parse tree which is gotten when the CSS code is parsed to build
+  a CSSOM tree.
 * Each CSS file is parsed into a ``StyleSheet object``, where each object
   contains CSS rules with selectors and objects corresponding CSS grammar.
 * A CSS parser can be top-down or bottom-up when a specific parser generator


### PR DESCRIPTION
The parsed CSS codes are used to build a model tree called the CSSOM, which is used to determine the rules of the webpage etc. how this model is created wasn't stated, so the change i made makes it known to the reader that there is a CSSOM available that is gotten by tokenizing the css and using that to render the CSS sheets.