### PR TITLE
Include LAN in DNS Lookup section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,7 +218,10 @@ DNS lookup
   resolve the hostname through DNS.
 * If ``gethostbyname`` does not have it cached nor can find it in the ``hosts``
   file then it makes a request to the DNS server configured in the network
-  stack. This is typically the local router or the ISP's caching DNS server.
+  stack.
+* If the device is connected to a LAN (Local Area Network), its DNS table is
+  looked up. If it isn't available, the local router or the ISP's caching DNS
+  server is next.
 * If the DNS server is on the same subnet the network library follows the
   ``ARP process`` below for the DNS server.
 * If the DNS server is on a different subnet, the network library follows


### PR DESCRIPTION
This inclusion applies if the user is connected to a Local Area Network of some sort