### PR TITLE
Create wm-keydowm

### DIFF
--- a/wm-keydowm
+++ b/wm-keydowm
@@ -1,0 +1,16 @@
+#Here's how we might use SendMessage for processing WM_KEYDOWN codes in the SYSMETS program:
+
+case WM_KEYDOWN:
+     switch (wParam)
+     {
+     case VK_HOME:
+          SendMessage (hwnd, WM_VSCROLL, SB_TOP, 0) ;
+          break ;
+
+     case VK_END:
+          SendMessage (hwnd, WM_VSCROLL, SB_BOTTOM, 0) ;
+          break ;
+
+     case VK_PRIOR:
+          SendMessage (hwnd, WM_VSCROLL, SB_PAGEUP, 0) ;
+          break ;


### PR DESCRIPTION
The three versions of the SYSMETS program in Chapter 4 were written without any knowledge of the keyboard. We were able to scroll the text only by using the mouse on the scroll bars. Now that we know how to process keystroke messages, let's add a keyboard interface to the program. This is obviously a job for cursor movement keys. We'll use most of these keys (Home, End, Page Up, Page Down, Up Arrow, and Down Arrow) for vertical scrolling. The Left Arrow and Right Arrow keys can take care of the less important horizontal scrolling.

One obvious way to create a keyboard interface is to add some WM_KEYDOWN logic to the window procedure that parallels and essentially duplicates all the WM_VSCROLL and WM_HSCROLL logic. However, this is unwise, because if we ever wanted to change the scroll bar logic we'd have to make the same changes in WM_KEYDOWN.

Wouldn't it be better to simply translate each of these WM_KEYDOWN messages into an equivalent WM_VSCROLL or WM_HSCROLL message? Then we could perhaps fool WndProc into thinking that it's getting a scroll bar message, perhaps by sending a phony message to the window procedure.

Windows lets you do this. The function is named SendMessage, and it takes the same parameters as those passed to the window procedure:

SendMessage (hwnd, message, wParam, lParam) ;
When you call SendMessage, Windows calls the window procedure whose window handle is hwnd, passing to it these four function arguments. When the window procedure has completed processing the message, Windows returns control to the next statement following the SendMessage call. The window procedure you send the message to could be the same window procedure, another window procedure in the same program, or even a window procedure in another application.