### PR TITLE
inconsistency in the statement regarding the ARP process

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,10 +219,10 @@ DNS lookup
 * If ``gethostbyname`` does not have it cached nor can find it in the ``hosts``
   file then it makes a request to the DNS server configured in the network
   stack. This is typically the local router or the ISP's caching DNS server.
-* If the DNS server is on the same subnet the network library follows the
-  ``ARP process`` below for the DNS server.
-* If the DNS server is on a different subnet, the network library follows
-  the ``ARP process`` below for the default gateway IP.
+* The ARP process is used to determine the MAC address of a device on the 
+  local network when the IP address is known. It is typically used in scenarios 
+  where two devices need to communicate within the same network segment. However, 
+  in the context of DNS resolution, the ARP process is not directly involved.
 
 
 ARP process


### PR DESCRIPTION
The ARP process is used to determine the MAC address of a device on the local network when the IP address is known. It is typically used in scenarios where two devices need to communicate within the same network segment. However, in the context of DNS resolution, the ARP process is not directly involved.