### PR TITLE
Introduce the concept of certificate chain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -380,8 +380,15 @@ TLS handshake
   the handshake until a symmetric key can be agreed upon.
 
 * The client verifies the server digital certificate against its list of
-  trusted CAs. If trust can be established based on the CA, the client
-  generates a string of pseudo-random bytes and encrypts this with the server's
+  trusted CAs. In many cases however, the certificate is not just one but a chain 
+  which includes intermediate CAs between the server's certificate and the root CA. 
+  These intermediate CAs play a crucial role in establishing a seamless chain of trust, 
+  effectively bridging the gap between the root CA and the server's certificate.
+  
+* As a result, the client needs to traverse the certificate chain, validating each
+  certificate starting from the server's certificate and progressing up the chain
+  until reaching the root CA certificate. If trust can be established based on the CA, 
+  the client generates a string of pseudo-random bytes and encrypts this with the server's
   public key. These random bytes can be used to determine the symmetric key.
 
 * The server decrypts the random bytes using its private key and uses these


### PR DESCRIPTION
Title: Enhancing DNS Lookup and TLS Handshake Explanation with the concept of Certificate Chain

Description:
This pull request aims to enhance the existing write-up on what happens when "https://www.google.com" is typed in a browser by incorporating a crucial concept related to the TLS handshake: the certificate chain and intermediate CAs. The proposed changes will provide readers with a more comprehensive understanding of how the TLS handshake establishes trust and ensures the authenticity of the server.