### PR TITLE
Fix typo in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ What happens when...
 
 This repository is an attempt to answer the age-old interview question "What
 happens when you type google.com into your browser's address box and press
-enter?"
+enter?."
 
 Except instead of the usual story, we're going to try to answer this question
 in as much detail as possible. No skipping out on anything.


### PR DESCRIPTION
Found small typo in the readme. it should read:
"This repository is an attempt to answer the age-old interview question 'What happens when you type google.com into your browser's address box and press enter?'."