### PR TITLE
Add CSS interpretation precedence

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -628,6 +628,9 @@ CSS interpretation
   contains CSS rules with selectors and objects corresponding CSS grammar.
 * A CSS parser can be top-down or bottom-up when a specific parser generator
   is used.
+* In cases where an external stylesheet, the ``<style>`` tag contents, and ``style`` attribute values are used, the browser uses the followind precedence:
+  * ``style`` attribute values
+  * ``<style>`` tag contents and external contents would be parsed based on a factor like specificity
 
 Page Rendering
 --------------


### PR DESCRIPTION
I added the order for processing CSS styles when the browser encounters the `style` element, `style` attribute and an external stylesheet