### PR TITLE
Update explanation about DNS lookup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,23 +206,16 @@ Check HSTS list
   `downgrade attack`_, which is why the HSTS list is included in modern web
   browsers.)
 
-DNS lookup
-----------
+DNS Lookup
+-----------
 
-* Browser checks if the domain is in its cache. (to see the DNS Cache in
-  Chrome, go to `chrome://net-internals/#dns <chrome://net-internals/#dns>`_).
-* If not found, the browser calls ``gethostbyname`` library function (varies by
-  OS) to do the lookup.
-* ``gethostbyname`` checks if the hostname can be resolved by reference in the
-  local ``hosts`` file (whose location `varies by OS`_) before trying to
-  resolve the hostname through DNS.
-* If ``gethostbyname`` does not have it cached nor can find it in the ``hosts``
-  file then it makes a request to the DNS server configured in the network
-  stack. This is typically the local router or the ISP's caching DNS server.
-* If the DNS server is on the same subnet the network library follows the
-  ``ARP process`` below for the DNS server.
-* If the DNS server is on a different subnet, the network library follows
-  the ``ARP process`` below for the default gateway IP.
+- The browser initially checks if the domain is present in its cache. To view the DNS Cache in Chrome, navigate to [chrome://net-internals/#dns](chrome://net-internals/#dns).
+- If the domain is not found in the cache, the browser invokes the `gethostbyname` library function, which varies depending on the operating system.
+- The `gethostbyname` function first checks if the hostname can be resolved by referencing the local `hosts` file. The location of this file varies by OS.
+- If the hostname is not cached in `gethostbyname` and cannot be found in the `hosts` file, the function sends a request to the DNS server configured in the network stack. Typically, this server is the local router or the ISP's caching DNS server.
+- If the DNS server is on the same subnet, the network library follows the "ARP process" below for the DNS server.
+- If the DNS server is on a different subnet, the network library follows the "ARP process" below for the default gateway IP.
+
 
 
 ARP process


### PR DESCRIPTION
This pull request introduces an explanation of the DNS lookup process to augment the current content. The DNS lookup process plays a pivotal role in translating domain names into IP addresses, facilitating browser access to websites. The incorporated explanation encompasses the following stages:

**DNS Cache Lookup:** The browser scrutinizes its DNS cache to ascertain whether the domain name is already stored, optimizing lookup times.

**Local Hosts File:** The browser examines the local hosts file, a mapping of domain names to IP addresses. If the domain name is present in the hosts file, the corresponding IP address is utilized.

**Invoking gethostbyname:** In cases where the domain name is not cached or located in the hosts file, the browser initiates a request to the network library's _gethostbyname_ function for DNS resolution.

**DNS Server Query:** The _gethostbyname_ function interrogates the DNS server configured in the network stack, such as the local router or the ISP's caching DNS server.

**ARP Process for DNS Server:** If the DNS server resides on the same subnet, the network library follows the ARP process to determine the MAC address of the DNS server.

**ARP Process for Default Gateway:** If the DNS server is situated on a different subnet, the network library follows the ARP process for the default gateway IP address.

This explanation furnishes a clear overview of the DNS lookup process, emphasizing the significance of DNS cache, the local hosts file, network library functions, and the roles of DNS servers and ARP in the resolution process.

Kindly review these amendments and contemplate merging them into the repository to enrich the existing documentation, offering readers a comprehensive grasp of the DNS lookup process.

Appreciate your consideration of this contribution.