### PR TITLE
docs: Clarify HSTS Explanation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -205,6 +205,8 @@ Check HSTS list
   single HTTP request could potentially leave the user vulnerable to a
   `downgrade attack`_, which is why the HSTS list is included in modern web
   browsers.)
+* HSTS can also be communicated by the server via the HTTP response header (Strict-Transport-Security).
+* If the site is not on the preloaded list but sends this header, the browser will still use HTTPS.
 
 DNS lookup
 ----------


### PR DESCRIPTION
Additions:
- Mention that HSTS can also be communicated by the server via the HTTP response header (Strict-Transport-Security).
- Clarify that if a site is not on the preloaded list but sends this header, the browser will still use HTTPS.

This clarification provides a more comprehensive understanding of how browsers handle HSTS policies.