### PR TITLE
DNS Lookup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -223,7 +223,8 @@ DNS lookup
   ``ARP process`` below for the DNS server.
 * If the DNS server is on a different subnet, the network library follows
   the ``ARP process`` below for the default gateway IP.
-
+* The DNS server receives the request and checks if it has the answer in its cache. If not, it performs a recursive or  
+  iterative query to find the answer.
 
 ARP process
 -----------


### PR DESCRIPTION
The DNS server receives the request and checks if it has the answer in its cache. If not, it performs a recursive or iterative query to find the answer.
A recursive query means that the DNS server will contact other DNS servers on behalf of the client until it finds the answer or an error occurs. An iterative query means that the DNS server will only return a referral to another DNS server that may have the answer, and the client has to contact that server directly. The choice of query type depends on the configuration of the DNS server and the client.