### PR TITLE
Add Authority "google.com" to the Parse URL section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,6 +171,9 @@ Parse URL
     - ``Protocol``  "http"
         Use 'Hyper Text Transfer Protocol'
 
+    - ``Authority``  "google.com"
+        Use the IP address that "google.com" resolves to to request the resource.
+
     - ``Resource``  "/"
         Retrieve main (index) page
 


### PR DESCRIPTION
Added the Authority that the index HTML page will be requested from, "google.com" in this case. After "google.com" has been resolved by the DNS to its IP address, this IP address is used to send the HTTP GET request to request the index HTML page.