### PR TITLE
Add section The 'enter' key bottoms out

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,13 @@ connection, but historically has been over PS/2 or ADB connections.
   device driver.  The value of the key is then passed into the operating
   system's hardware abstraction layer.
 
+- Keyboard Controller: Inside the keyboard, a dedicated microcontroller known as
+  the keyboard controller plays a pivotal role. It manages tasks such as
+  scanning the state of each key switch, eliminating electrical noise through
+  debouncing, and converting physical keypresses into digital keycode integers.
+  Once the keycode is generated, the keyboard controller facilitates its
+  transmission to the computer's USB host controller for further processing.
+
 *In the case of Virtual Keyboard (as in touch screen devices):*
 
 - When the user puts their finger on a modern capacitive touch screen, a


### PR DESCRIPTION
This commit adds a new section titled "The 'enter' key bottoms out" to the existing documentation. The section provides detailed information about the electrical and protocol processes involved when the Enter key on a keyboard is pressed, focusing specifically on USB keyboards. Additionally, a new subsection titled "Keyboard Controller" has been included to elaborate on the role of the keyboard controller in managing keypress signals and facilitating their transmission to the computer's USB host controller. This contribution aims to enhance the understanding of keyboard functionality and USB communication protocols within the project documentation.