### PR TITLE
Add host as google.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,6 +171,8 @@ Parse URL
     - ``Protocol``  "http"
         Use 'Hyper Text Transfer Protocol'
 
+        ``Host`` "www.google.com"
+
     - ``Resource``  "/"
         Retrieve main (index) page
 


### PR DESCRIPTION
In URL Parse section, I added host as google.com to ease understanding that host is www.google.com wich is part of what is parsed.