### PR TITLE
Replace gethostbyname with getaddrinfo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,12 +211,12 @@ DNS lookup
 
 * Browser checks if the domain is in its cache. (to see the DNS Cache in
   Chrome, go to `chrome://net-internals/#dns <chrome://net-internals/#dns>`_).
-* If not found, the browser calls ``gethostbyname`` library function (varies by
+* If not found, the browser calls ``getaddrinfo`` library function (varies by
   OS) to do the lookup.
-* ``gethostbyname`` checks if the hostname can be resolved by reference in the
+* ``getaddrinfo`` checks if the hostname can be resolved by reference in the
   local ``hosts`` file (whose location `varies by OS`_) before trying to
   resolve the hostname through DNS.
-* If ``gethostbyname`` does not have it cached nor can find it in the ``hosts``
+* If ``getaddrinfo`` does not have it cached nor can find it in the ``hosts``
   file then it makes a request to the DNS server configured in the network
   stack. This is typically the local router or the ISP's caching DNS server.
 * If the DNS server is on the same subnet the network library follows the


### PR DESCRIPTION
gethostbyname is deprecated and POSIX now recommends getaddrinfo
